### PR TITLE
Use our own rules reference and severity, even when the issue comes from the AWS ruleset

### DIFF
--- a/rules/ensure_default_tags_rule.go
+++ b/rules/ensure_default_tags_rule.go
@@ -113,14 +113,14 @@ func (r *EnsureDefaultTagsRule) Check(runner tflint.Runner) error {
 		// If there are issues with both missing default tags and missing resource tags, output all issues found
 		if len(providerDefaultTagIssues) > 0 && len(awsRunner.Issues) > 0 {
 			for _, issue := range providerDefaultTagIssues {
-				err := runner.EmitIssue(issue.Rule, issue.Message, issue.Range)
+				err := runner.EmitIssue(r, issue.Message, issue.Range)
 				if err != nil {
 					return err
 				}
 			}
 
 			for _, issue := range awsRunner.Issues {
-				err := runner.EmitIssue(issue.Rule, issue.Message, issue.Range)
+				err := runner.EmitIssue(r, issue.Message, issue.Range)
 				if err != nil {
 					return err
 				}

--- a/rules/ensure_default_tags_rule_test.go
+++ b/rules/ensure_default_tags_rule_test.go
@@ -5,7 +5,6 @@ import (
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
-	awsRules "github.com/terraform-linters/tflint-ruleset-aws/rules"
 )
 
 func Test_EnsureDefaultTagsRule(t *testing.T) {
@@ -116,7 +115,7 @@ func Test_EnsureDefaultTagsRule(t *testing.T) {
 					},
 				},
 				{
-					Rule:    awsRules.NewAwsResourceMissingTagsRule(),
+					Rule:    NewEnsureDefaultTagsRule(),
 					Message: "The resource is missing the following tags: \"team\".",
 					Range: hcl.Range{
 						Filename: "resource.tf",

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,7 +9,3 @@ import (
 func NewIssue(rule tflint.Rule, message string, issueRange hcl.Range) helper.Issue {
 	return helper.Issue{Rule: rule, Message: message, Range: issueRange}
 }
-
-func EmitIssue(runner tflint.Runner, issue helper.Issue) error {
-	return runner.EmitIssue(issue.Rule, issue.Message, issue.Range)
-}


### PR DESCRIPTION
This is useful to be able to control severity directly from our own rule
